### PR TITLE
Fixed digest encoding

### DIFF
--- a/cryptmd5.js
+++ b/cryptmd5.js
@@ -47,7 +47,7 @@ exports.cryptMD5 = function(pw, salt) {
     ctx1.update(pw);
 	ctx1.update(sp);
 	ctx1.update(pw);
-	var fin = ctx1.digest();
+	var fin = ctx1.digest("binary");
 
 	for(var i = 0; i < pw.length ; i++) {
 		ctx.update(fin.substr(i % 16, 1));
@@ -62,7 +62,7 @@ exports.cryptMD5 = function(pw, salt) {
 		ctx.update ( (i & 1) ? "\x00" : pw[0] );
 	}
 
-	fin = ctx.digest();
+	fin = ctx.digest("binary");
 
 	// and now, just to make sure things don't run too fast
     for (var i = 0; i < 1000; i++) {
@@ -88,7 +88,7 @@ exports.cryptMD5 = function(pw, salt) {
             ctx1.update(pw);
 		}
 
-        fin = ctx1.digest()
+        fin = ctx1.digest("binary")
 	}
 
 	return magic + sp + '$' + to64(fin);


### PR DESCRIPTION
binary is no longer the default return encoding for hash.digest()

```
/app/cryptmd5.js:54
        ctx.update(fin.substr(i % 16, 1));
                       ^
TypeError: undefined is not a function
    at Object.exports.cryptMD5 (/app/cryptmd5.js:54:18)
    at Object.<anonymous> (/app/index.js:21:23)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```

a buffer was returned. see [crypto api](https://nodejs.org/api/crypto.html#crypto_hash_digest_encoding)
